### PR TITLE
Links should point to codecov/...

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [3]: mailto:hello@codecov.io
 [4]: https://github.com/codecov/codecov-bash
 
-[![codecov](https://codecov.io/gh/codecov/example-typescript/branch/master/graph/badge.svg)](https://codecov.io/gh/eddiemoore/example-typescript)
-[![Build Status](https://travis-ci.org/codecov/example-typescript.svg?branch=master)](https://travis-ci.org/eddiemoore/example-typescript)
+[![codecov](https://codecov.io/gh/codecov/example-typescript/branch/master/graph/badge.svg)](https://codecov.io/gh/codecov/example-typescript)
+[![Build Status](https://travis-ci.org/codecov/example-typescript.svg?branch=master)](https://travis-ci.org/codecov/example-typescript)
 
 Run npm install:
 ```shell


### PR DESCRIPTION
The replaced links go to error pages on the services.  The new links work.

Nice example by the way!  I've been looking for a good set up to start with writing
typescript components.
